### PR TITLE
Add volume-delta indicator

### DIFF
--- a/indicators/chriselderxyz/volume-delta.json
+++ b/indicators/chriselderxyz/volume-delta.json
@@ -1,0 +1,23 @@
+{
+  "type": "indicator",
+  "name": "Volume Delta",
+  "data": {
+    "libraryId": "volume-delta",
+    "displayName": "Volume Delta",
+    "options": {
+      "priceScaleId": "_9xmhdhmj2pf5zrgv",
+      "scaleMargins": {
+        "top": 0.1,
+        "bottom": 0.2
+      },
+      "exchange": 0,
+      "type": 0,
+      "chartTitle": ""
+    },
+    "script": "// Options //\n\n// Filters\nexchange = option(default=null, type=exchange, rebuild=true)\ntype = option(default=null, type=list, options=[\"spot\", \"perp\"], rebuild=true)\n\n// Chart\nchartTitle = option(default=\"Delta\", type=text, rebuild=true)\nupColor = option(default=\"#42bda8\", type=color, rebuild=true)\ndownColor = option(default=\"#f77c80\", type=color, rebuild=true)\n\n// Get Filtered Sources //\nvar src = source(type=type, exchange=exchange)\n\n// Calculate Volume Delta //\nvar delta = 0\n\nfor (const [key, value] of Object.entries(src.sources)) {\n  delta = delta + value.vbuy - value.vsell\n}\n\n// Get Color //\nvar chartColor = delta > 0 ? upColor : downColor\n\n// Plot Delta //\n histogram(\n  {\n    value: delta,\n    time: time,\n    color: chartColor\n  },\n  title = chartTitle\n)",
+    "createdAt": 1729970010068,
+    "updatedAt": 1729970046285,
+    "presets": [],
+    "author": "chriselderxyz"
+  }
+}


### PR DESCRIPTION
Add a volume delta indicator to the community scripts

Features:
- Plots a histogram of volume delta
- Allows filtering by a single exchange and spot vs. perps using script options

Use Case:
- Allows for multiple volume delta indicators for different exchanges to more easily compare buy & sell volume between venues
- Allows for volume delta to be displayed for just spot or just perp assets

Notes:
- First indicator I'm submitting, let me know if there are any issues
- Couldn't find a way to generate the png's included with the other community indicators, let me know if that's required